### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ Django Laconic URLS
 .. image:: https://travis-ci.org/robert-b-clarke/django-laconicurls.svg?branch=master
     :target: https://travis-ci.org/robert-b-clarke/django-laconicurls
 
-.. image:: https://pypip.in/v/django-laconicurls/badge.png
+.. image:: https://img.shields.io/pypi/v/django-laconicurls.svg
     :target: https://pypi.python.org/pypi//django-laconicurls/
     :alt: Downloads
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20django-laconicurls))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `django-laconicurls`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.